### PR TITLE
Add material property to Volume class

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -256,7 +256,7 @@ class Volume(DAGSet):
 
         if not existing_group:
             # Create new group and add entity
-            group_id = max(g.id for g in self.model.groups.values()) + 1
+            group_id = max((g.id for g in self.model.groups.values()), default=0) + 1
             new_group = Group.create(self.model, name=f"mat:{name}", group_id=group_id)
             new_group.add_set(self)
 

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
 from abc import abstractmethod
 from functools import cached_property
-from pathlib import Path
-from typing import Any
+from typing import Optional, Dict
 
 import numpy as np
-
 from pymoab import core, types, rng
+
 
 class DAGModel:
 
@@ -31,7 +31,7 @@ class DAGModel:
         return {v.id: v for v in volumes}
 
     @property
-    def groups(self):
+    def groups(self) -> Dict[str, Group]:
         group_handles = self._sets_by_category('Group')
 
         group_mapping = {}
@@ -75,7 +75,7 @@ class DAGSet:
     """
     Generic functionality for a DAGMC EntitySet.
     """
-    def __init__(self, model, handle):
+    def __init__(self, model: DAGModel, handle):
         self.model = model
         self.handle = handle
 
@@ -224,6 +224,40 @@ class Surface(DAGSet):
 
 class Volume(DAGSet):
 
+    @property
+    def groups(self) -> list[Group]:
+        """Get list of groups containing this volume."""
+        return [group for group in self.model.groups.values() if self in group]
+
+    @property
+    def material(self) -> Optional[str]:
+        """Name of the material assigned to this volume."""
+        for group in self.groups:
+            if self in group and group.name.startswith("mat:"):
+                return group.name[4:]
+        return None
+
+    @material.setter
+    def material(self, name: str):
+        existing_group = False
+        for group in self.model.groups.values():
+            if f"mat:{name}" == group.name:
+                # Add volume to group matching specified name, unless the volume
+                # is already in it
+                if self in group:
+                    return
+                group.add_set(self)
+                existing_group = True
+
+            elif self in group and group.name.startswith("mat:"):
+                # Remove volume from existing group
+                group.remove_set(self)
+
+        if not existing_group:
+            # Create new group, add name/category tags, add entity
+            new_group = Group.create(self.model, name=f"mat:{name}")
+            new_group.add_set(self)
+
     def get_surfaces(self):
         """Returns surface objects for all surfaces making up this vollume"""
         surfs = [Surface(self.model, h) for h in self.model.mb.get_child_meshsets(self.handle)]
@@ -238,13 +272,16 @@ class Volume(DAGSet):
 
 class Group(DAGSet):
 
+    def __contains__(self, ent_set: DAGSet):
+        return any(vol.handle == ent_set.handle for vol in self.get_volumes().values())
+
     @property
-    def name(self):
+    def name(self) -> str:
         """Returns the name of this group."""
         return self.model.mb.tag_get_data(self.model.name_tag, self.handle, flat=True)[0]
 
     @name.setter
-    def name(self, val):
+    def name(self, val: str):
         self.model.mb.tag_set_data(self.model.name_tag, self.handle, val)
 
     def _get_geom_ent_by_id(self, entity_type, id):
@@ -333,7 +370,7 @@ class Group(DAGSet):
         other_group.handle = self.handle
 
     @classmethod
-    def create(cls, model, name=None, group_id=None):
+    def create(cls, model, name=None, group_id=None) -> Group:
         """Create a new group instance with the given name"""
         mb = model.mb
         # add necessary tags for this meshset to be identified as a group

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import abstractmethod
 from functools import cached_property
+from itertools import chain
 from typing import Optional, Dict
 
 import numpy as np
@@ -254,8 +255,9 @@ class Volume(DAGSet):
                 group.remove_set(self)
 
         if not existing_group:
-            # Create new group, add name/category tags, add entity
-            new_group = Group.create(self.model, name=f"mat:{name}")
+            # Create new group and add entity
+            group_id = max(g.id for g in self.model.groups.values()) + 1
+            new_group = Group.create(self.model, name=f"mat:{name}", group_id=group_id)
             new_group.add_set(self)
 
     def get_surfaces(self):
@@ -273,7 +275,8 @@ class Volume(DAGSet):
 class Group(DAGSet):
 
     def __contains__(self, ent_set: DAGSet):
-        return any(vol.handle == ent_set.handle for vol in self.get_volumes().values())
+        return any(vol.handle == ent_set.handle for vol in chain(
+            self.get_volumes().values(), self.get_surfaces().values()))
 
     @property
     def name(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/pshriwise/pydagmc"
+"Homepage" = "https://github.com/svalinn/pydagmc"
 
 
 [project.optional-dependencies]

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -111,6 +111,21 @@ def test_group_merge(request):
     assert 3 in fuel_group.get_volumes()
 
 
+def test_volume(request):
+    test_file = str(request.path.parent / 'fuel_pin.h5m')
+    model = dagmc.DAGModel(test_file)
+
+    v1 = model.volumes[1]
+    assert v1.material == 'fuel'
+    assert v1 in model.groups['mat:fuel']
+
+    v1.material = 'olive oil'
+    assert v1.material == 'olive oil'
+    assert 'mat:olive oil' in model.groups
+    assert v1 in model.groups['mat:olive oil']
+    assert v1 not in model.groups['mat:fuel']
+
+
 def test_compressed_coords(request, capfd):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     groups = dagmc.DAGModel(test_file).groups


### PR DESCRIPTION
This PR implements a new `material` property on the `Volume` class that gives users an easy way to change the material assigned to a volume without having to manually mess around with the associated groups. 