### PR TITLE
Implement `forward_volume` and `reverse_volume` properties in Surface

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -303,9 +303,12 @@ class Surface(DAGSet):
     @property
     def surf_sense(self) -> list[Optional[Volume]]:
         """Surface sense data."""
-        handles = self.model.mb.tag_get_data(
-            self.model.surf_sense_tag, self.handle, flat=True
-        )
+        try:
+            handles = self.model.mb.tag_get_data(
+                self.model.surf_sense_tag, self.handle, flat=True
+            )
+        except RuntimeError:
+            return [None, None]
         return [Volume(self.model, handle) if handle != 0 else None
                 for handle in handles]
 
@@ -325,10 +328,7 @@ class Surface(DAGSet):
     @property
     def forward_volume(self) -> Optional[Volume]:
         """Volume with forward sense with respect to the surface."""
-        try:
-            return self.surf_sense[0]
-        except RuntimeError:
-            return None
+        return self.surf_sense[0]
 
     @forward_volume.setter
     def forward_volume(self, volume: Volume):
@@ -337,10 +337,7 @@ class Surface(DAGSet):
     @property
     def reverse_volume(self) -> Optional[Volume]:
         """Volume with reverse sense with respect to the surface."""
-        try:
-            return self.surf_sense[1]
-        except RuntimeError:
-            return None
+        return self.surf_sense[1]
 
     @reverse_volume.setter
     def reverse_volume(self, volume: Volume):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -135,6 +135,14 @@ def test_surface(request):
     assert s1.forward_volume == model.volumes[1]
     assert s1.reverse_volume == model.volumes[2]
 
+    s1.forward_volume = model.volumes[3]
+    assert s1.forward_volume == model.volumes[3]
+    assert s1.surf_sense == [model.volumes[3], model.volumes[2]]
+
+    s1.reverse_volume = model.volumes[1]
+    assert s1.reverse_volume == model.volumes[1]
+    assert s1.surf_sense == [model.volumes[3], model.volumes[1]]
+
 
 def test_hash(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -125,6 +125,16 @@ def test_volume(request):
     assert v1 not in model.groups['mat:fuel']
 
 
+def test_surface(request):
+    test_file = str(request.path.parent / 'fuel_pin.h5m')
+    model = dagmc.DAGModel(test_file)
+
+    s1 = model.surfaces[1]
+    assert s1.get_volumes == [model.volumes[1], model.volumes[2]]
+    assert s1.forward_volume == model.volumes[1]
+    assert s1.reverse_volume == model.volumes[2]
+
+
 def test_hash(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -130,7 +130,7 @@ def test_surface(request):
     model = dagmc.DAGModel(test_file)
 
     s1 = model.surfaces[1]
-    assert s1.get_volumes == [model.volumes[1], model.volumes[2]]
+    assert s1.get_volumes() == [model.volumes[1], model.volumes[2]]
     assert s1.forward_volume == model.volumes[1]
     assert s1.reverse_volume == model.volumes[2]
 


### PR DESCRIPTION
This PR adds `forward_volume` and `reverse_volume` properties in the `Surface` class, which in turn rely on a lower-level `surf_sense` property. There was also a small bug in the `get_volumes()` method that is now fixed.