### PR TITLE
Adding option to write file from the `DAGModel` class.

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -90,6 +90,15 @@ class DAGModel:
             create_if_missing=True,
         )
 
+    def write_file(self, filename):
+        """Write the model to a file.
+
+        Parameters
+        ----------
+        filename : str
+            The file to write to.
+        """
+        self.mb.write_file(filename)
 
 class DAGSet:
     """

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -270,3 +270,11 @@ def test_delete(fuel_pin_model):
     assert 'mat:fuel' not in model.groups
 
 
+def test_write(request, tmpdir):
+    test_file = str(request.path.parent / 'fuel_pin.h5m')
+    model = dagmc.DAGModel(test_file)
+    model.volumes[1].id = 12345
+    model.write_file('fuel_pin_copy.h5m')
+
+    model = dagmc.DAGModel('fuel_pin_copy.h5m')
+    assert 12345 in model.volumes

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -256,6 +256,7 @@ def test_eq(request):
 
     assert model1_v0 != model2_v0
 
+
 def test_delete(fuel_pin_model):
     model = dagmc.DAGModel(fuel_pin_model)
 


### PR DESCRIPTION
After making a set of changes to a DAGMC model, it would be convenient to be able to write the file from the model class to incorporate all changes without accessing the `pymoab.core.Core` object. This adds a small wrapper to do so.