### PR TITLE
Adding a method to delete sets

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -279,6 +279,11 @@ class DAGSet:
         tri_map = {eh: c for eh, c in zip(triangle_handles, conn)}
         return tri_map, coords
 
+    def delete(self):
+        """Delete this group from the DAGMC file."""
+        self.model.mb.delete_entity(self.handle)
+        self.handle = None
+        self.model = None
 
 class Surface(DAGSet):
 


### PR DESCRIPTION
This should of course be used wisely, but it makes sense to be able to remove sets. For instance, one might want to replace group assignments entirely. This would make it easier to do so.