### PR TITLE
Add DAGSet.create classmethod

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -306,6 +306,20 @@ class DAGSet:
         self.handle = None
         self.model = None
 
+    @classmethod
+    def create(cls, model: DAGModel, global_id: Optional[int] = None) -> Surface:
+        """Create new set"""
+        # Add necessary tags for this meshset to be identified appropriately
+        ent_set = DAGSet(model, model.mb.create_meshset())
+        ent_set.geom_dimension = cls._geom_dimension
+        ent_set.category = cls._category
+        if global_id is not None:
+            ent_set.id = global_id
+
+        # Now that entity set has proper tags, create derived class and return
+        return cls(model, ent_set.handle)
+
+
 class Surface(DAGSet):
 
     _category = 'Surface'
@@ -451,6 +465,7 @@ class Volume(DAGSet):
             sign = 1 if surface.forward_volume == self else -1
             volume += sign * sum
         return volume / 6.0
+
 
 class Group(DAGSet):
 

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -30,7 +30,7 @@ class DAGModel:
     @property
     def surfaces(self):
         return [Surface(self, h) for h in self._sets_by_category('Surface')]
-    
+
     @property
     def surfaces_by_id(self):
         return {s.id: s for s in self.surfaces}
@@ -464,12 +464,13 @@ class Volume(DAGSet):
         """Get list of groups containing this volume."""
         return [group for group in self.model.groups if self in group]
 
+    @property
     def _material_group(self):
         for group in self.groups:
             if "mat:" in group.name:
                 return group
         return None
-    
+
     @property
     def material(self) -> Optional[str]:
         """Name of the material assigned to this volume."""
@@ -494,7 +495,7 @@ class Volume(DAGSet):
     def surfaces(self):
         """Returns surface objects for all surfaces making up this vollume"""
         return [Surface(self.model, h) for h in self.model.mb.get_child_meshsets(self.handle)]
-    
+
     @property
     def surfaces_by_id(self):
         return {s.id: s for s in self.surfaces}
@@ -578,7 +579,7 @@ class Group(DAGSet):
     def volumes(self):
         """Returns a list of Volume objects for the volumes contained by the group set."""
         return [Volume(self.model, v) for v in self._get_geom_ent_sets('Volume')]
-    
+
     @property
     def volumes_by_id(self):
         return {v.id: v for v in self.volumes}
@@ -587,7 +588,7 @@ class Group(DAGSet):
     def surfaces(self):
         """Returns a list of Surface objects for the surfaces contained by the group set."""
         return [Surface(self.model, s) for s in self._get_geom_ent_sets('Surface')]
-    
+
     @property
     def surfaces_by_id(self):
         return {s.id: s for s in self.surfaces}
@@ -648,7 +649,7 @@ class Group(DAGSet):
 
     @classmethod
     def create(cls, model: DAGModel, name: Optional[str] = None, group_id: Optional[int] = None) -> Group:
-        """Create a new group instance with the given name, 
+        """Create a new group instance with the given name,
         or return an existing group if one exists."""
 
         # return existing group if one exists with this name

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -366,11 +366,11 @@ class DAGSet:
         ent_set = DAGSet(model, model.mb.create_meshset())
         ent_set.geom_dimension = cls._geom_dimension
         ent_set.category = cls._category
+        # Now that the entity set has proper tags, create derived class and return
+        out = cls(model, ent_set.handle)
         if global_id is not None:
-            ent_set.id = global_id
-
-        # Now that entity set has proper tags, create derived class and return
-        return cls(model, ent_set.handle)
+            out.id = global_id
+        return out
 
 
 class Surface(DAGSet):

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -360,7 +360,7 @@ class DAGSet:
         self.model = None
 
     @classmethod
-    def create(cls, model: DAGModel, global_id: Optional[int] = None) -> Surface:
+    def create(cls, model: DAGModel, global_id: Optional[int] = None) -> DAGSet:
         """Create new set"""
         # Add necessary tags for this meshset to be identified appropriately
         ent_set = DAGSet(model, model.mb.create_meshset())

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -121,14 +121,14 @@ def test_volume(request):
 
     v1.material = 'olive oil'
     assert v1.material == 'olive oil'
-    assert 'mat:olive oil' in model.groups
+    assert 'mat:olive oil' in model.groups_by_name
     assert v1 in model.groups_by_name['mat:olive oil']
     assert v1 not in model.groups_by_name['mat:fuel']
 
     new_vol = dagmc.Volume.create(model, 100)
     assert isinstance(new_vol, dagmc.Volume)
     assert new_vol.id == 100
-    assert model.volumes[100] == new_vol
+    assert model.volumes_by_id[100] == new_vol
 
 
 def test_surface(request):
@@ -157,7 +157,7 @@ def test_id_safety(request):
     used_vol_id = 2
     with pytest.raises(ValueError, match="already"):
         v1.id = used_vol_id
-    
+
     safe_vol_id = 9876
     v1.id = safe_vol_id
     assert v1.id == safe_vol_id
@@ -167,7 +167,7 @@ def test_id_safety(request):
     used_surf_id = 2
     with pytest.raises(ValueError, match="already"):
         s1.id = used_surf_id
-    
+
     safe_surf_id = 9876
     s1.id = safe_surf_id
     assert s1.id == safe_surf_id
@@ -177,7 +177,7 @@ def test_id_safety(request):
     used_grp_id = 2
     with pytest.raises(ValueError, match="already"):
         g1.id = used_grp_id
-    
+
     safe_grp_id = 9876
     g1.id = safe_grp_id
     assert g1.id == safe_grp_id
@@ -209,7 +209,6 @@ def test_compressed_coords(request, capfd):
 
     fuel_group = groups['mat:fuel']
     v1 = fuel_group.volumes_by_id[1]
-    print(v1)
 
     conn, coords = v1.get_triangle_conn_and_coords()
     uconn, ucoords = v1.get_triangle_conn_and_coords(compress=True)
@@ -343,7 +342,7 @@ def test_write(request, tmpdir):
     assert 12345 in model.volumes_by_id
 
 
-def test_volume(request):
+def test_volume_value(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)
     exp_vols = {1: np.pi * 7**2 * 40,

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -186,7 +186,7 @@ def test_id_safety(request):
     new_surf = dagmc.Surface.create(model, 100)
     assert isinstance(new_surf, dagmc.Surface)
     assert new_surf.id == 100
-    assert model.surfaces[100] == new_surf
+    assert model.surfaces_by_id[100] == new_surf
 
 
 def test_hash(request):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -127,6 +127,11 @@ def test_volume(request):
     assert v1 in model.groups['mat:olive oil']
     assert v1 not in model.groups['mat:fuel']
 
+    new_vol = dagmc.Volume.create(model, 100)
+    assert isinstance(new_vol, dagmc.Volume)
+    assert new_vol.id == 100
+    assert model.volumes[100] == new_vol
+
 
 def test_surface(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
@@ -144,6 +149,11 @@ def test_surface(request):
     s1.reverse_volume = model.volumes[1]
     assert s1.reverse_volume == model.volumes[1]
     assert s1.surf_sense == [model.volumes[3], model.volumes[1]]
+
+    new_surf = dagmc.Surface.create(model, 100)
+    assert isinstance(new_surf, dagmc.Surface)
+    assert new_surf.id == 100
+    assert model.surfaces[100] == new_surf
 
 
 def test_hash(request):


### PR DESCRIPTION
This PR adds a `DAGSet.create` classmethod that can be used to create new volumes/surfaces that functions similar to the `Group.create` classmethod:
```Python
vol = dagmc.Volume.create(model, ...)
surf = dagmc.Surface.create(model, ...)
```

One thought I had regarding design is that it might be better to have `create` methods on the `DAGModel` class instead since the model always has to get passed, so that the above example would look like:
```Python
vol = model.create_volume(...)
surf = model.create_surface(...)
```
