### PR TITLE
Cleanup group handling and make many functions into properties

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -468,7 +468,7 @@ class Volume(DAGSet):
             # Remove volume from existing group
             group.remove_set(self)
 
-        # create a new group or ge an existing group
+        # create a new group or get an existing group
         group = Group.create(self.model, name=f"mat:{name}")
         group.add_set(self)
 

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -134,10 +134,10 @@ class DAGModel:
                 if isinstance(dagset, DAGSet):
                     group.add_set(dagset)
                 else:
-                    if dagset in self.volumes:
-                        group.add_set(self.volumes[dagset])
-                    elif dagset in self.surfaces:
-                        group.add_set(self.surfaces[dagset])
+                    if dagset in self.volumes_by_id:
+                        group.add_set(self.volumes_by_id[dagset])
+                    elif dagset in self.surfaces_by_id:
+                        group.add_set(self.surfaces_by_id[dagset])
                     else:
                         raise ValueError(f"DAGSet ID={dagset} could not be "
                                          "found in model volumes or surfaces.")

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -55,7 +55,7 @@ class DAGModel:
         return group_mapping
 
     def __repr__(self):
-        return f'{type(self).__name__} {self.id}, {self.num_triangles()} triangles'
+        return f'{type(self).__name__} {self.id}, {self.num_triangles} triangles'
 
     @cached_property
     def id_tag(self):
@@ -188,7 +188,7 @@ class DAGSet:
         return hash((self.handle, id(self.model)))
 
     def __repr__(self):
-        return f'{type(self).__name__} {self.id}, {self.num_triangles()} triangles'
+        return f'{type(self).__name__} {self.id}, {self.num_triangles} triangles'
 
     def _tag_get_data(self, tag: tag.Tag):
         return self.model.mb.tag_get_data(tag, self.handle, flat=True)[0]

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -132,18 +132,18 @@ def test_surface(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)
 
-    s1 = model.surfaces[1]
-    assert s1.volumes == [model.volumes[1], model.volumes[2]]
-    assert s1.forward_volume == model.volumes[1]
-    assert s1.reverse_volume == model.volumes[2]
+    s1 = model.surfaces_by_id[1]
+    assert s1.volumes == [model.volumes_by_id[1], model.volumes_by_id[2]]
+    assert s1.forward_volume == model.volumes_by_id[1]
+    assert s1.reverse_volume == model.volumes_by_id[2]
 
-    s1.forward_volume = model.volumes[3]
-    assert s1.forward_volume == model.volumes[3]
-    assert s1.surf_sense == [model.volumes[3], model.volumes[2]]
+    s1.forward_volume = model.volumes_by_id[3]
+    assert s1.forward_volume == model.volumes_by_id[3]
+    assert s1.surf_sense == [model.volumes_by_id[3], model.volumes_by_id[2]]
 
-    s1.reverse_volume = model.volumes[1]
-    assert s1.reverse_volume == model.volumes[1]
-    assert s1.surf_sense == [model.volumes[3], model.volumes[1]]
+    s1.reverse_volume = model.volumes_by_id[1]
+    assert s1.reverse_volume == model.volumes_by_id[1]
+    assert s1.surf_sense == [model.volumes_by_id[3], model.volumes_by_id[1]]
 
 
 def test_hash(request):
@@ -298,7 +298,7 @@ def test_write(request, tmpdir):
     model.write_file('fuel_pin_copy.h5m')
 
     model = dagmc.DAGModel('fuel_pin_copy.h5m')
-    assert 12345 in model.volumes
+    assert 12345 in model.volumes_by_id
 
 
 def test_volume(request):
@@ -331,8 +331,8 @@ def test_area(request):
 def test_add_groups(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)
-    volumes = model.volumes
-    surfaces = model.surfaces
+    volumes = model.volumes_by_id
+    surfaces = model.surfaces_by_id
 
     for group in model.groups.values():
         group.delete()

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -169,7 +169,7 @@ def test_id_safety(request):
     s1.id = safe_surf_id
     assert s1.id == safe_surf_id
 
-    g1 = groups['mat:fuel']
+    g1 = model.groups['mat:fuel']
 
     used_grp_id = 2
     with pytest.raises(ValueError, match="already"):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -45,7 +45,7 @@ def test_basic_functionality(request, capfd):
     fuel_group = groups['mat:fuel']
     print(fuel_group)
 
-    v1 = fuel_group.get_volumes()[1]
+    v1 = fuel_group.volumes_by_id[1]
     print(v1)
 
     groups['mat:fuel'].remove_set(v1)
@@ -80,7 +80,7 @@ def test_group_merge(request):
     groups = model.groups
 
     orig_group = groups['mat:fuel']
-    orig_group_size = len(orig_group.get_volumes())
+    orig_group_size = len(orig_group.volumes)
     # create a new group with the same name as another group
     new_group = dagmc.Group.create(model, 'mat:fuel')
     assert orig_group != new_group
@@ -103,14 +103,14 @@ def test_group_merge(request):
         new_group.add_set(vol)
 
     assert orig_group != new_group
-    assert len((new_group.get_volume_ids())) == len(model.volumes)
+    assert len((new_group.volume_ids)) == len(model.volumes)
 
     # now get the groups again
     groups = model.groups
     # the group named 'mat:fuel' should contain the additional
     # volume set w/ ID 3 now
     fuel_group = groups['mat:fuel']
-    assert 3 in fuel_group.get_volumes()
+    assert 3 in fuel_group.volumes_by_id
 
 
 def test_volume(request):
@@ -133,7 +133,7 @@ def test_surface(request):
     model = dagmc.DAGModel(test_file)
 
     s1 = model.surfaces[1]
-    assert s1.get_volumes() == [model.volumes[1], model.volumes[2]]
+    assert s1.volumes == [model.volumes[1], model.volumes[2]]
     assert s1.forward_volume == model.volumes[1]
     assert s1.reverse_volume == model.volumes[2]
 
@@ -166,17 +166,17 @@ def test_compressed_coords(request, capfd):
     groups = dagmc.DAGModel(test_file).groups
 
     fuel_group = groups['mat:fuel']
-    v1 = fuel_group.get_volumes()[1]
+    v1 = fuel_group.volumes_by_id[1]
     print(v1)
 
     conn, coords = v1.get_triangle_conn_and_coords()
     uconn, ucoords = v1.get_triangle_conn_and_coords(compress=True)
 
-    for i in range(v1.num_triangles()):
+    for i in range(v1.num_triangles):
         assert (coords[conn[i]] == ucoords[uconn[i]]).all()
 
     conn_map, coords = v1.get_triangle_coordinate_mapping()
-    tris = v1.get_triangle_handles()
+    tris = v1.triangle_handles
     assert (conn_map[tris[0]].size == 3)
     assert (coords[conn_map[tris[0]]].size == 9)
 
@@ -189,10 +189,10 @@ def test_coords(request, capfd):
     group = groups['mat:fuel']
     conn, coords = group.get_triangle_conn_and_coords()
 
-    volume = next(iter(group.get_volumes().values()))
+    volume = next(iter(group.volumes))
     conn, coords = volume.get_triangle_conn_and_coords(compress=True)
 
-    surface = next(iter(volume.get_surfaces().values()))
+    surface = next(iter(volume.surfaces))
     conn, coords = surface.get_triangle_conn_and_coords(compress=True)
 
 
@@ -285,7 +285,7 @@ def test_delete(fuel_pin_model):
 
     # attempt an operation on the group
     with pytest.raises(AttributeError, match="has no attribute 'mb'"):
-        fuel_group.get_volumes()
+        fuel_group.volumes
 
     # ensure the group is no longer returned by the model
     assert 'mat:fuel' not in model.groups
@@ -351,8 +351,8 @@ def test_add_groups(request):
     groups = model.groups
 
     assert len(groups) == 5
-    assert [1, 2] == sorted(groups['mat:fuel'].get_volume_ids())
-    assert [6] == groups['mat:Graveyard'].get_volume_ids()
-    assert [3] == groups['mat:41'].get_volume_ids()
-    assert [27, 28, 29] == sorted(groups['boundary:Reflecting'].get_surface_ids())
-    assert [24, 25] == sorted(groups['boundary:Vacuum'].get_surface_ids())
+    assert [1, 2] == sorted(groups['mat:fuel'].volume_ids)
+    assert [6] == groups['mat:Graveyard'].volume_ids
+    assert [3] == groups['mat:41'].volume_ids
+    assert [27, 28, 29] == sorted(groups['boundary:Reflecting'].surface_ids)
+    assert [24, 25] == sorted(groups['boundary:Vacuum'].surface_ids)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -81,7 +81,7 @@ def test_group_merge(request):
 
     orig_group = groups['mat:fuel']
     orig_group_size = len(orig_group.volumes)
-    # try tp create a new group with the same name as another group
+    # try to create a new group with the same name as another group
     new_group = dagmc.Group.create(model, 'mat:fuel')
     assert orig_group == new_group
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -99,7 +99,7 @@ def test_group_merge(request):
     new_group = dagmc.Group.create(model, 'mat:fuel')
 
     # add one of other volumes to the new set
-    for vol in model.volumes.values():
+    for vol in model.volumes:
         new_group.add_set(vol)
 
     assert orig_group != new_group

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -159,6 +159,27 @@ def test_id_safety(request):
     v1.id = safe_vol_id
     assert v1.id == safe_vol_id
 
+    s1 = model.surfaces_by_id[1]
+
+    used_surf_id = 2
+    with pytest.raises(ValueError, match="already"):
+        s1.id = used_surf_id
+    
+    safe_surf_id = 9876
+    s1.id = safe_surf_id
+    assert s1.id == safe_surf_id
+
+    g1 = groups['mat:fuel']
+
+    used_grp_id = 2
+    with pytest.raises(ValueError, match="already"):
+        g1.id = used_grp_id
+    
+    safe_grp_id = 9876
+    g1.id = safe_grp_id
+    assert g1.id == safe_grp_id
+
+
 
 def test_hash(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -81,15 +81,13 @@ def test_group_merge(request):
 
     orig_group = groups['mat:fuel']
     orig_group_size = len(orig_group.volumes)
-    # create a new group with the same name as another group
+    # try tp create a new group with the same name as another group
     new_group = dagmc.Group.create(model, 'mat:fuel')
-    assert orig_group != new_group
+    assert orig_group == new_group
 
     # check that we can update a set ID
-    assert new_group.id == -1
     new_group.id = 100
     assert new_group.id == 100
-
 
     # merge the new group into the existing group
     orig_group.merge(new_group)
@@ -102,7 +100,7 @@ def test_group_merge(request):
     for vol in model.volumes:
         new_group.add_set(vol)
 
-    assert orig_group != new_group
+    assert orig_group == new_group
     assert len((new_group.volume_ids)) == len(model.volumes)
 
     # now get the groups again
@@ -373,11 +371,11 @@ def test_add_groups(request):
 
     assert len(model.groups) == 0
 
-    group_map = {("mat:fuel", 1): [1, 2],
-                 ("mat:Graveyard", 0): [volumes[6]],
-                 ("mat:41", 2): [3],
-                 ("boundary:Reflecting", 3): [27, 28, 29],
-                 ("boundary:Vacuum", 4): [surfaces[24], surfaces[25]]
+    group_map = {("mat:fuel", 10): [1, 2],
+                 ("mat:Graveyard", 50): [volumes[6]],
+                 ("mat:41", 20): [3],
+                 ("boundary:Reflecting", 30): [27, 28, 29],
+                 ("boundary:Vacuum", 40): [surfaces[24], surfaces[25]]
                  }
 
     model.add_groups(group_map)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -117,7 +117,7 @@ def test_volume(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)
 
-    v1 = model.volumes[1]
+    v1 = model.volumes_by_id[1]
     assert v1.material == 'fuel'
     assert v1 in model.groups['mat:fuel']
 
@@ -145,12 +145,25 @@ def test_surface(request):
     assert s1.reverse_volume == model.volumes_by_id[1]
     assert s1.surf_sense == [model.volumes_by_id[3], model.volumes_by_id[1]]
 
+def test_id_safety(request):
+    test_file = str(request.path.parent / 'fuel_pin.h5m')
+    model = dagmc.DAGModel(test_file)
+
+    v1 = model.volumes_by_id[1]
+
+    used_vol_id = 2
+    with pytest.raises(ValueError, match="already"):
+        v1.id = used_vol_id
+    
+    safe_vol_id = 9876
+    v1.id = safe_vol_id
+    assert v1.id == safe_vol_id
+
 
 def test_hash(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)
 
-    s = set(model.volumes)
     d = {group: group.name for group in model.groups.values()}
 
     # check that an entry for the same volume with a different model can be entered
@@ -294,7 +307,7 @@ def test_delete(fuel_pin_model):
 def test_write(request, tmpdir):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)
-    model.volumes[1].id = 12345
+    model.volumes_by_id[1].id = 12345
     model.write_file('fuel_pin_copy.h5m')
 
     model = dagmc.DAGModel('fuel_pin_copy.h5m')
@@ -307,9 +320,9 @@ def test_volume(request):
     exp_vols = {1: np.pi * 7**2 * 40,
                 2: np.pi * (9**2 - 7**2) * 40,
                 3: np.pi * (10**2 - 9**2) * 40,}
-    pytest.approx(model.volumes[1].volume, exp_vols[1])
-    pytest.approx(model.volumes[2].volume, exp_vols[2])
-    pytest.approx(model.volumes[3].volume, exp_vols[3])
+    pytest.approx(model.volumes_by_id[1].volume, exp_vols[1])
+    pytest.approx(model.volumes_by_id[2].volume, exp_vols[2])
+    pytest.approx(model.volumes_by_id[3].volume, exp_vols[3])
 
 
 def test_area(request):


### PR DESCRIPTION
Improve group handling to ensure that duplicate groups with the same name are never created.

Keep a cache of Surface/Volume/Group ids to ensure that we don't reuse an ID already in use.

Makes many getter functions into properties and updates their calls.

Closes #12 
Closes #15 

