### PR TITLE
update MOAB version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           cd ~
           git clone https://bitbucket.org/fathomteam/moab.git
           cd moab
-          git checkout 5.3.1
+          git checkout 5.5.1
           mkdir build
           cd build
           cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
This appears to work using the newest release of MOAB.

Note: it probably makes sense to update the HDF5 version being used, but rebuilding it for each CI will slow things down.  The alternative gets us into more complicated CI space.

Fixes #16 