### PR TITLE
Add create methods on DAGModel class

### DIFF
--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -156,6 +156,19 @@ class DAGModel:
                         raise ValueError(f"DAGSet ID={dagset} could not be "
                                          "found in model volumes or surfaces.")
 
+    def create_group(self, name: Optional[str] = None, group_id: Optional[int] = None) -> Group:
+        """Create a new group instance with the given name,
+        or return an existing group if one exists."""
+        return Group.create(self, name, group_id)
+
+    def create_volume(self, global_id: Optional[int] = None) -> Volume:
+        """Create a new volume"""
+        return Volume.create(self, global_id)
+
+    def create_surface(self, global_id: Optional[int] = None) -> Surface:
+        """Create a new surface"""
+        return Surface.create(self, global_id)
+
 
 class DAGSet:
     """

--- a/dagmc/dagnav.py
+++ b/dagmc/dagnav.py
@@ -157,16 +157,16 @@ class DAGModel:
                                          "found in model volumes or surfaces.")
 
     def create_group(self, name: Optional[str] = None, group_id: Optional[int] = None) -> Group:
-        """Create a new group instance with the given name,
+        """Create a new empty group instance with the given name,
         or return an existing group if one exists."""
         return Group.create(self, name, group_id)
 
     def create_volume(self, global_id: Optional[int] = None) -> Volume:
-        """Create a new volume"""
+        """Create a new empty volume set"""
         return Volume.create(self, global_id)
 
     def create_surface(self, global_id: Optional[int] = None) -> Surface:
-        """Create a new surface"""
+        """Create a new empty surface set"""
         return Surface.create(self, global_id)
 
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -100,6 +100,9 @@ def test_group_merge(request):
     for vol in model.volumes:
         new_group.add_set(vol)
 
+    # using create_group should give same thing
+    assert model.create_group('mat:fuel') == new_group
+
     assert orig_group == new_group
     assert len((new_group.volume_ids)) == len(model.volumes)
 
@@ -130,6 +133,10 @@ def test_volume(request):
     assert new_vol.id == 100
     assert model.volumes_by_id[100] == new_vol
 
+    new_vol2 = model.create_volume(200)
+    assert isinstance(new_vol2, dagmc.Volume)
+    assert new_vol2.id == 200
+    assert model.volumes_by_id[200] == new_vol2
 
 def test_surface(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
@@ -187,6 +194,11 @@ def test_id_safety(request):
     assert isinstance(new_surf, dagmc.Surface)
     assert new_surf.id == 100
     assert model.surfaces_by_id[100] == new_surf
+
+    new_surf2 = model.create_surface(200)
+    assert isinstance(new_surf2, dagmc.Surface)
+    assert new_surf2.id == 200
+    assert model.surfaces_by_id[200] == new_surf2
 
 
 def test_hash(request):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -114,6 +114,22 @@ def test_group_merge(request):
     assert 3 in fuel_group.volumes_by_id
 
 
+def test_group_create(request):
+    test_file = str(request.path.parent / 'fuel_pin.h5m')
+    model = dagmc.DAGModel(test_file)
+    orig_num_groups = len(model.groups)
+
+    # Create two new groups
+    new_group1 = dagmc.Group.create(model, 'mat:slime')
+    new_group2 = model.create_group('mat:plastic')
+
+    assert 'mat:slime' in model.groups_by_name
+    assert 'mat:plastic' in model.groups_by_name
+    assert model.groups_by_name['mat:slime'] == new_group1
+    assert model.groups_by_name['mat:plastic'] == new_group2
+    assert len(model.groups) == orig_num_groups + 2
+
+
 def test_volume(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
     model = dagmc.DAGModel(test_file)


### PR DESCRIPTION
This PR builds on #13 to provide`create_group`, `create_volume` and `create_surface` methods on the `DAGModel` class that simply delegate to the underlying `DAGSet.create` and `Group.create` classmethods.