### PR TITLE
Ensure that groups attribute is indexable

### DIFF
--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -62,7 +62,7 @@ class DAGModel:
 
     @property
     def groups(self):
-        return self.groups_by_name.values()
+        return list(self.groups_by_name.values())
 
     @property
     def groups_by_name(self) -> Dict[str, Group]:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -43,9 +43,12 @@ def test_model_repr(fuel_pin_model):
 
 def test_basic_functionality(request, capfd):
     test_file = str(request.path.parent / 'fuel_pin.h5m')
-    groups = pydagmc.DAGModel(test_file).groups_by_name
-
+    model = pydagmc.DAGModel(test_file)
+    groups = model.groups_by_name
     print(groups)
+    # ensure that the groups attribude is indexable
+    first_group = model.groups[0]
+    assert isinstance(first_group, pydagmc.Group)
 
     fuel_group = groups['mat:fuel']
     print(fuel_group)


### PR DESCRIPTION
This PR ensures that the groups returns from the `DAGModel.groups` attribute is indexable (it is currently a `dict_values` object). Adds a test indexing this attribute to ensure this is true.