### PR TITLE
Test coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Test w/ coverage
         shell: bash
         run: |
-          pytest . -v --cov=pydagmc --cov-branch --cov-report=xml --cov-report=term-missing
+          pytest . -v --cov=src/pydagmc --cov-branch --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           file: coverage.xml
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
           name: codecov-umbrella
 
       - name: tmate debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,7 @@ jobs:
                       scipy \
                       matplotlib \
                       h5py \
-                      pytest \
-                      pytest-cov \
-                      codecov
+                      pytest
 
       - name: Build MOAB
         shell: bash
@@ -59,12 +57,12 @@ jobs:
       - name: Install
         shell: bash
         run: |
-          pip install .
+          pip install .[test,ci]
 
-      - name: Test
+      - name: Test w/ coverage
         shell: bash
         run: |
-          pytest -v .
+          pytest . -v --cov=pydagmc
 
       - name: tmate debug
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install
         shell: bash
         run: |
-          pip install .[test,ci]
+          pip install -e .[test,ci]
 
       - name: Test w/ coverage
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,14 @@ jobs:
       - name: Test w/ coverage
         shell: bash
         run: |
-          pytest . -v --cov=pydagmc
+          pytest . -v --cov=pydagmc --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v2
+        with:
+          file: coverage.xml
+          flags: unittests
+          name: codecov-umbrella
 
       - name: tmate debug
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Test w/ coverage
         shell: bash
         run: |
-          pytest . -v --cov=pydagmc --cov-report=xml --cov-report=term-missing
+          pytest . -v --cov=pydagmc --cov-branch --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pydagmc.egg-info/
 
 # Source build
 build
+.coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/svalinn/pydagmc/actions/workflows/ci.yml/badge.svg)](https://github.com/svalinn/pydagmc/actions/workflows/ci.yml)
 
+[![codecov](https://codecov.io/github/svalinn/pydagmc/graph/badge.svg?token=TONI94VBED)](https://codecov.io/github/svalinn/pydagmc)
+
 PyDAGMC is a Python interface for interacting with DAGMC .h5m files through the embedded topological relationships and metadata contained within. These interactions occur through a set of Python classes corresponding to DAGMC’s metadata Group (a grouping of volumes or surfaces), Volume, and Surface groupings in the mesh database. This interface is intended to provide a simple interface for obtaining information about DAGMC models, replacing significant boilerplate code required to perform the same queries with PyMOAB, the Python interface for MOAB itself.
 
 PyDAGMC classes provide the ability to perform basic queries as properties of the class instances. These queries include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = ["numpy"]
 # Optional Dependencies
 [project.optional-dependencies]
 test = ["pytest"]
+ci = ["pytest-cov"]
 
 # Project URLs
 [project.urls]


### PR DESCRIPTION
This adds a simple testing coverage report to CI.

- [x] Needs configuration with a token from the Svalinn codecov account (I think)