### PR TITLE
Adding MOAB installation cache for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,7 @@ jobs:
         name: Build MOAB
         shell: bash
         run: |
-          cd ~
-          git clone https://bitbucket.org/fathomteam/moab.git
-          cd moab
-          git checkout 5.5.1
+          cd ~/moab
           mkdir build
           cd build
           cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_BUILD_TYPE=Release ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
         env:
           cache-name: cache-moab
         with:
-          path: ~/moab
+          path: |
+            ~/moab
+            ~/opt
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.MOAB_SHA }}
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
@@ -73,15 +75,13 @@ jobs:
           git checkout 5.5.1
           mkdir build
           cd build
-          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/moab -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_BUILD_TYPE=Release ..
           make -j4
 
       - name: Install PyMOAB
         shell: bash
         run: |
-          cd ~/moab
-          make install
-          cd pymoab
+          cd ~/moab/build
           pip3 install .
 
       - name: Install PyDAGMC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install PyMOAB
         shell: bash
         run: |
-          cd ~/moab/build
+          cd ~/moab/build/pymoab
           pip3 install .
 
       - name: Install PyDAGMC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,30 @@ jobs:
                       pytest-cov \
                       codecov
 
-      - name: Build MOAB
+      - name: Clone MOAB
+        shell: bash
+        run: |
+          cd ~
+          git clone https://bitbucket.org/fathomteam/moab.git
+          cd moab
+          git checkout 5.5.1
+
+      - name: MOAB SHA Environment Variable
+        shell: bash
+        run: |
+          echo "MOAB_SHA=$(cd ~/moab && git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: MOAB Cache
+        id: moab-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-moab
+        with:
+          path: ~/moab
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.MOAB_SHA }}
+
+      - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
+        name: Build MOAB
         shell: bash
         run: |
           cd ~
@@ -50,13 +73,18 @@ jobs:
           git checkout 5.5.1
           mkdir build
           cd build
-          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/moab -DCMAKE_BUILD_TYPE=Release ..
           make -j4
+
+      - name: Install PyMOAB
+        shell: bash
+        run: |
+          cd ~/moab
           make install
           cd pymoab
           pip3 install .
 
-      - name: Install
+      - name: Install PyDAGMC
         shell: bash
         run: |
           pip install .


### PR DESCRIPTION
This adds a cache for the MOAB clone and build step in CI, which currently takes the majority of the time.

The PyMOAB installation with `pip` still occurs for every run -- I think it would be more trouble than it's worth to try to cache the installation itself. In the future caching a wheel made with `scikit-build` might make sense.