### PR TITLE
Install MOAB/PyMOAB using Conda in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,17 @@ jobs:
           activate-environment: pydagmc-ci
 
       - name: Install MOAB
-        shell: bash
+        shell: bash -l {0}
         run: |
           conda install -y -c conda-forge moab=5.5.1
 
       - name: Install PyDAGMC
-        shell: bash
+        shell: bash -l {0}
         run: |
           pip install .[test]
 
       - name: Test PyDAGMC
-        shell: bash
+        shell: bash -l {0}
         run: |
           pytest -v .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          activate-environment: pydagmc-ci
+          channels: conda-forge
+          mamba-version: "*"
           auto-activate-base: false
+          activate-environment: pydagmc-ci
 
       - name: Install MOAB
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,51 +17,23 @@ jobs:
         with:
           submodules: true
 
-      - name: Apt dependencies
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: pydagmc-ci
+          auto-activate-base: false
+
+      - name: Install MOAB
         shell: bash
         run: |
-          sudo apt -y update
-          sudo apt install -y libgcc-9-dev \
-                              libstdc++-9-dev \
-                              libembree-dev \
-                              python3-dev \
-                              libhdf5-dev \
-                              libeigen3-dev \
-                              cmake
+          conda install -y -c conda-forge moab=5.5.1
 
-      - name: Python dependencies
-        shell: bash
-        run: |
-          pip3 install numpy \
-                      cython==0.29.37 \
-                      scipy \
-                      matplotlib \
-                      h5py \
-                      pytest \
-                      pytest-cov \
-                      codecov
-
-      - name: Build MOAB
-        shell: bash
-        run: |
-          cd ~
-          git clone https://bitbucket.org/fathomteam/moab.git
-          cd moab
-          git checkout 5.5.1
-          mkdir build
-          cd build
-          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_BUILD_TYPE=Release ..
-          make -j4
-          make install
-          cd pymoab
-          pip3 install .
-
-      - name: Install
+      - name: Install PyDAGMC
         shell: bash
         run: |
           pip install .
 
-      - name: Test
+      - name: Test PyDAGMC
         shell: bash
         run: |
           pytest -v .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install PyDAGMC
         shell: bash
         run: |
-          pip install .
+          pip install .[test]
 
       - name: Test PyDAGMC
         shell: bash


### PR DESCRIPTION
This installs MOAB/PyMOAB from Conda in CI at the suggestion of @ahnaf-tahmid-chowdhury. CI turnaround is now ~90s. Nice!