### PR TITLE
Add faceting_tol_tag property and other small updates

### DIFF
--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -28,6 +28,8 @@ except ImportError as e:
 
 class DAGModel:
 
+    mb: core.Core
+
     def __init__(self, moab_file=None):
         if isinstance(moab_file, core.Core):
             self.mb = moab_file

--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -308,6 +308,17 @@ class DAGSet:
             filename += '.vtk'
         self.model.mb.write_file(filename, output_sets=[self.handle])
 
+    def load_file(self, filename):
+        """Load data from a file into this set.
+
+        Parameters
+        ----------
+        filename : str
+            The file to read from.
+
+        """
+        self.model.mb.load_file(filename, self.handle)
+
     @property
     def triangle_handles(self):
         """Returns a pymoab.rng.Range of all triangle handles under this set.

--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -28,12 +28,13 @@ except ImportError as e:
 
 class DAGModel:
 
-    def __init__(self, moab_file):
+    def __init__(self, moab_file=None):
         if isinstance(moab_file, core.Core):
             self.mb = moab_file
         else:
             self.mb = core.Core()
-            self.mb.load_file(moab_file)
+            if moab_file is not None:
+                self.mb.load_file(moab_file)
 
         self.used_ids = {}
         self.used_ids[Surface] = set(self.surfaces_by_id.keys())
@@ -135,6 +136,17 @@ class DAGModel:
             "GEOM_SENSE_2",
             2,
             types.MB_TYPE_HANDLE,
+            types.MB_TAG_SPARSE,
+            create_if_missing=True,
+        )
+
+    @cached_property
+    def faceting_tol_tag(self):
+        """Faceting tolerance tag."""
+        return self.mb.tag_get_handle(
+            "FACETING_TOL",
+            1,
+            types.MB_TYPE_DOUBLE,
             types.MB_TAG_SPARSE,
             create_if_missing=True,
         )
@@ -470,7 +482,7 @@ class Surface(DAGSet):
         return [Volume(self.model, h) for h in self.model.mb.get_parent_meshsets(self.handle)]
 
     @property
-    def num_triangles(self):
+    def num_triangles(self) -> int:
         """Returns the number of triangles in this surface"""
         return len(self.triangle_handles)
 
@@ -478,7 +490,7 @@ class Surface(DAGSet):
         return [self]
 
     @property
-    def area(self):
+    def area(self) -> float:
         """Returns the area of the surface"""
         conn, coords = self.get_triangle_conn_and_coords()
         sum = 0.0
@@ -530,16 +542,16 @@ class Volume(DAGSet):
         group.add_set(self)
 
     @property
-    def surfaces(self):
+    def surfaces(self) -> list[Surface]:
         """Returns surface objects for all surfaces making up this vollume"""
         return [Surface(self.model, h) for h in self.model.mb.get_child_meshsets(self.handle)]
 
     @property
-    def surfaces_by_id(self):
+    def surfaces_by_id(self) -> dict[int, Surface]:
         return {s.id: s for s in self.surfaces}
 
     @property
-    def num_triangles(self):
+    def num_triangles(self) -> int:
         """Returns the number of triangles in this volume"""
         return sum([s.num_triangles for s in self.surfaces])
 
@@ -547,7 +559,7 @@ class Volume(DAGSet):
         return [s.handle for s in self.surfaces]
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """Returns the volume of the volume"""
         volume = 0.0
         for surface in self.surfaces:
@@ -614,21 +626,21 @@ class Group(DAGSet):
         return self.model.mb.tag_get_data(self.model.id_tag, self._get_geom_ent_sets(entity_type), flat=True)
 
     @property
-    def volumes(self):
+    def volumes(self) -> list[Volume]:
         """Returns a list of Volume objects for the volumes contained by the group set."""
         return [Volume(self.model, v) for v in self._get_geom_ent_sets('Volume')]
 
     @property
-    def volumes_by_id(self):
+    def volumes_by_id(self) -> dict[int, Volume]:
         return {v.id: v for v in self.volumes}
 
     @property
-    def surfaces(self):
+    def surfaces(self) -> list[Surface]:
         """Returns a list of Surface objects for the surfaces contained by the group set."""
         return [Surface(self.model, s) for s in self._get_geom_ent_sets('Surface')]
 
     @property
-    def surfaces_by_id(self):
+    def surfaces_by_id(self) -> dict[int, Surface]:
         return {s.id: s for s in self.surfaces}
 
     @property

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -330,9 +330,8 @@ def test_to_vtk(tmpdir_factory, request):
 @pytest.mark.parametrize("category,dim", [('Surface', 2), ('Volume', 3), ('Group', 4)])
 def test_empty_category(category, dim):
     # Create a volume that has no category assigned
-    mb = core.Core()
-    model = pydagmc.DAGModel(mb)
-    ent_set = pydagmc.DAGSet(model, mb.create_meshset())
+    model = pydagmc.DAGModel()
+    ent_set = pydagmc.DAGSet(model, model.mb.create_meshset())
     ent_set.geom_dimension = dim
 
     # Instantiating using the proper class (Surface, Volume, Group) should
@@ -359,7 +358,7 @@ def test_empty_geom_dimension(category, dim):
 
 @pytest.mark.parametrize("cls", [pydagmc.Surface, pydagmc.Volume, pydagmc.Group])
 def test_missing_tags(cls):
-    model = pydagmc.DAGModel(core.Core())
+    model = pydagmc.DAGModel()
     handle = model.mb.create_meshset()
     with pytest.raises(ValueError):
         cls(model, handle)


### PR DESCRIPTION
This PR makes a few small changes to support moving stellarmesh from its own set of classes that manage DAGMC models to using pydagmc as a dependency. There were a few things missing, namely:
- stellarmesh sets the `faceting_tol` tag, which is needed by `make_watertight`. As discussed offline by @pshriwise and I, give that there are now numerous ways to produce DAGMC files, the faceting tolerance should just be an argument to `make_watertight` rather than something that is stored intrinsically on the `DAGModel`.
- The `DAGModel` constructor was updated so that if you call it with no arguments, it will create/assign the `pymoab.core.Core()` object for you
- Because stellarmesh loads data from an STL into a specific entity set in order to build up the model, I've added a `load_file` method on the `DAGSet` class