### PR TITLE
Ensuring other types can be compared to DAGSet without raising an exception

### DIFF
--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -228,8 +228,6 @@ class DAGSet:
             raise ValueError(f"{identifier} has no category or geom_dimension tags assigned.")
 
     def __eq__(self, other):
-        if type(other) != type(self):
-            return False
         return type(other) == type(self) and \
                self.model == other.model and \
                self.handle == other.handle

--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -228,7 +228,11 @@ class DAGSet:
             raise ValueError(f"{identifier} has no category or geom_dimension tags assigned.")
 
     def __eq__(self, other):
-        return self.model == other.model and self.handle == other.handle
+        if type(other) != type(self):
+            return False
+        return type(other) == type(self) and \
+               self.model == other.model and \
+               self.handle == other.handle
 
     def __hash__(self):
         return hash((self.handle, id(self.model)))

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -375,6 +375,12 @@ def test_eq(request):
 
     assert model1_v0.handle == model2_v0.handle
 
+    # ensure we can check other types against sets
+    # without error
+    assert None != model1_v0
+    assert 1 != model1_v0
+    assert 10.0 != model1_v0
+
     assert model1_v0 != model2_v0
 
 


### PR DESCRIPTION
Title kind of says it all. I was trying to do the following today:

```python
for surf in model.surfaces:
    if None in surf.surf_sense:
        ...
```

And had an exception raised due to a missing attribute on `NoneType` for the `None` <--> `DAGSet` comparison.
