### PR TITLE
Rename Surface.surf_sense property to Surface.senses

### DIFF
--- a/src/pydagmc/dagnav.py
+++ b/src/pydagmc/dagnav.py
@@ -421,7 +421,7 @@ class Surface(DAGSet):
         self._check_category_and_dimension()
 
     @property
-    def surf_sense(self) -> list[Optional[Volume]]:
+    def senses(self) -> list[Optional[Volume]]:
         """Surface sense data."""
         try:
             handles = self.model.mb.tag_get_data(
@@ -432,10 +432,10 @@ class Surface(DAGSet):
         return [Volume(self.model, handle) if handle != 0 else None
                 for handle in handles]
 
-    @surf_sense.setter
-    def surf_sense(self, volumes: list[Optional[Volume]]):
+    @senses.setter
+    def senses(self, volumes: list[Optional[Volume]]):
         if len(volumes) != 2:
-            raise ValueError("surf_sense should be a list of two volumes.")
+            raise ValueError("Senses should be a list of two volumes.")
         sense_data = [vol.handle if vol is not None else np.uint64(0)
                       for vol in volumes]
         self._tag_set_data(self.model.surf_sense_tag, sense_data)
@@ -448,20 +448,20 @@ class Surface(DAGSet):
     @property
     def forward_volume(self) -> Optional[Volume]:
         """Volume with forward sense with respect to the surface."""
-        return self.surf_sense[0]
+        return self.senses[0]
 
     @forward_volume.setter
     def forward_volume(self, volume: Volume):
-        self.surf_sense = [volume, self.reverse_volume]
+        self.senses = [volume, self.reverse_volume]
 
     @property
     def reverse_volume(self) -> Optional[Volume]:
         """Volume with reverse sense with respect to the surface."""
-        return self.surf_sense[1]
+        return self.senses[1]
 
     @reverse_volume.setter
     def reverse_volume(self, volume: Volume):
-        self.surf_sense = [self.forward_volume, volume]
+        self.senses = [self.forward_volume, volume]
 
     @property
     def volumes(self) -> list[Volume]:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -173,11 +173,11 @@ def test_surface(request):
 
     s1.forward_volume = model.volumes_by_id[3]
     assert s1.forward_volume == model.volumes_by_id[3]
-    assert s1.surf_sense == [model.volumes_by_id[3], model.volumes_by_id[2]]
+    assert s1.senses == [model.volumes_by_id[3], model.volumes_by_id[2]]
 
     s1.reverse_volume = model.volumes_by_id[1]
     assert s1.reverse_volume == model.volumes_by_id[1]
-    assert s1.surf_sense == [model.volumes_by_id[3], model.volumes_by_id[1]]
+    assert s1.senses == [model.volumes_by_id[3], model.volumes_by_id[1]]
 
 def test_id_safety(request):
     test_file = str(request.path.parent / 'fuel_pin.h5m')


### PR DESCRIPTION
Given that this is a property of the `Surface` class, the `surf_` prefix seems redundant. 


**Note: this will be a breaking change**