### PR TITLE
Checkout repostitory tags In PyPI workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The dynamic versioning in `setuptools-scm` infers versions from tags in the repository. We'll need those in PyPI publishing workflows to produce wheels with valid version specifiers accepted by `pypa`.

https://packaging.python.org/en/latest/specifications/version-specifiers/