### PR TITLE
description on one line to avoid truncation on PyPI search results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ authors = [
     { name = "Jonathan Shimwell", email = "drshimwell@gmail.com" }
 ]
 description = """
-A convenience interface for examining,
-modifying, and creating, DAGMC models using PyMOAB
+A convenience interface for examining, modifying, and creating, DAGMC models using PyMOAB
 """
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
The `description` in the `pyproject.toml` file was over two lines and only the first is shown in a PyPI search results.  This puts it on a single line to improve the search results.